### PR TITLE
fix: skip branch check when running on GHA

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -79,7 +79,8 @@ target.releaseNext = () => {
 
 target.releaseLatest = async () => {
   const currentBranch = exec('git rev-parse --abbrev-ref HEAD').stdout.trim();
-  if (currentBranch !== 'master') {
+  console.log(`Current branch: ${currentBranch}`);
+  if (!process.env.GITHUB_ACTIONS && currentBranch !== 'master') {
     console.error('Must be on `master` branch to cut an @latest release.');
     return;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptact/fontkit",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "An advanced font engine for Node and the browser",
   "main": "dist/fontkit.umd.js",
   "unpkg": "dist/fontkit.umd.min.js",


### PR DESCRIPTION
Github Action `publish` workflow runs on release tags so the check in the existing `Makefile.js` to ensure that you are on `master` is not relevant when running CI/CD from GHA. Added a check skip the branch check when running on GH as the [default environment variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) define `GITHUB_ACTIONS` to indicate that it is running in CI.